### PR TITLE
Fix minus-warning.

### DIFF
--- a/src/varint.toit
+++ b/src/varint.toit
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 MSB_ ::= 0b10000000
-MASK_ ::= ~(MSB_-1)
+MASK_ ::= ~(MSB_ - 1)
 
 encode p/ByteArray offset/int i/int -> int:
   if i & 0x7f == i:


### PR DESCRIPTION
It's not allowed to have a variable followed by '-' directly anymore.